### PR TITLE
feature/about ie에서 개발팀 소개 페이지의 썸네일이 깨지는 이슈 수정

### DIFF
--- a/_sass/_about.scss
+++ b/_sass/_about.scss
@@ -51,7 +51,6 @@
       margin: 0;
       float: left;
       border-radius: 50%;
-      //width: 100%;
       height: 100%;
       object-fit: cover;
       position: initial;

--- a/_sass/_about.scss
+++ b/_sass/_about.scss
@@ -51,7 +51,7 @@
       margin: 0;
       float: left;
       border-radius: 50%;
-      width: 100%;
+      //width: 100%;
       height: 100%;
       object-fit: cover;
       position: initial;


### PR DESCRIPTION
- IE에서만 썸네일이 깨지는 이슈가 발생하여 수정