### PR TITLE
Revert "feature/about ie에서 개발팀 소개 페이지의 썸네일이 깨지는 이슈 수정"

### DIFF
--- a/_sass/_about.scss
+++ b/_sass/_about.scss
@@ -82,6 +82,7 @@
       margin: 0;
       float: left;
       border-radius: 50%;
+      width: 100%;
       height: 100%;
       object-fit: cover;
       position: initial;


### PR DESCRIPTION
Reverts oy-alldev/oy-alldev.github.io#92